### PR TITLE
refactor atoms tests

### DIFF
--- a/src/components/atoms/Cart/Cart.test.js
+++ b/src/components/atoms/Cart/Cart.test.js
@@ -5,8 +5,12 @@ import '@testing-library/jest-dom'
 
 
 test('renders Cart icon', () => {
-  const { getByTestId } = render(<Cart/>);
-  const cartIcon = getByTestId('LocalMallIcon');
+  const { container } = render(<Cart />);
+  
+  const cartIcon = container.querySelector('svg');
+  
   expect(cartIcon).toBeInTheDocument();
   expect(cartIcon).toHaveClass('MuiSvgIcon-root');
+  expect(cartIcon).toHaveStyle('color: white');
 });
+

--- a/src/components/atoms/RatingStars/Rating.test.js
+++ b/src/components/atoms/RatingStars/Rating.test.js
@@ -5,9 +5,9 @@ import '@testing-library/jest-dom'
 
 
 test('renders rating component', () => {
-  const { getByTestId} = render(<RatingStars stars={4}/>);
- 
-  const component = getByTestId('rating');
+  const { getByRole } = render(<RatingStars stars={4} />);
 
-  expect(component).toBeInTheDocument();
+  const ratingComponent = getByRole('img');
+  
+  expect(ratingComponent).toBeInTheDocument();
 });

--- a/src/components/atoms/SearchButton/SearhcButton.test.js
+++ b/src/components/atoms/SearchButton/SearhcButton.test.js
@@ -5,20 +5,19 @@ import '@testing-library/jest-dom'
 
 
 test('renders search button', () => {
-  const { getByTestId } = render(<SearchButton/>);
-  const searchbtn = getByTestId('search-btn');
-  expect(searchbtn).toBeInTheDocument();
+  const { getByRole } = render(<SearchButton />);
+  const searchButton = getByRole('button', { name: /search/i }); // Query by role and button text
+  expect(searchButton).toBeInTheDocument();
 });
 
 test('renders search button with undefined onClick prop', () => {
-  const { getByTestId } = render(<SearchButton onClick={undefined} />);
-  const searchbtn = getByTestId('search-btn');
-  expect(searchbtn).toBeInTheDocument();
+  const { getByRole } = render(<SearchButton onClick={undefined} />);
+  const searchButton = getByRole('button', { name: /search/i });
+  expect(searchButton).toBeInTheDocument();
 });
 
 test('does not crash when the button is clicked with no onClick handler', () => {
-  const { getByTestId } = render(<SearchButton />);
-  const searchbtn = getByTestId('search-btn');
-  expect(() => fireEvent.click(searchbtn)).not.toThrow();
+  const { getByRole } = render(<SearchButton />);
+  const searchButton = getByRole('button', { name: /search/i });
+  expect(() => fireEvent.click(searchButton)).not.toThrow();
 });
-

--- a/src/components/atoms/Textfield/Textfield.test.js
+++ b/src/components/atoms/Textfield/Textfield.test.js
@@ -5,37 +5,39 @@ import '@testing-library/jest-dom'
 
 
 test('renders textfield for destination', () => {
-  const { getByTestId } = render(<Textfield/>);
-  const textfield = getByTestId('texfield');
+  const { container } = render(<Textfield/>);
+  const textfield = container.querySelector('input');
   expect(textfield).toBeInTheDocument();
 });
 
 test('renders textfield without onChange prop', () => {
-  const { getByTestId } = render(<Textfield />);
-  const textfield = getByTestId('texfield');
+  const { container } = render(<Textfield/>);
+  const textfield = container.querySelector('input');
   expect(textfield).toBeInTheDocument();
 });
 
 test('renders textfield with undefined onChange prop', () => {
-  const { getByTestId } = render(<Textfield onChange={undefined} />);
-  const textfield = getByTestId('texfield');
+  const { container } = render(<Textfield onChange={undefined} />);
+  const textfield = container.querySelector('input');
   expect(textfield).toBeInTheDocument();
 });
 
 test('displays error when showError is true', () => {
-  const { getByTestId } = render(<Textfield showError={true} />);
-  const textfield = getByTestId('texfield');
-  expect(textfield).toHaveClass('MuiFormControl-root MuiTextField-root Textfield css-134uato-MuiFormControl-root-MuiTextField-root');
+  const { container } = render(<Textfield showError={true} />);
+  const textfield = container.querySelector('input');
+  expect(textfield).toBeInTheDocument();
+  expect(container.querySelector('.Textfield')).toHaveClass('MuiFormControl-root');
+  expect(container.querySelector('.Textfield')).toHaveClass('MuiTextField-root');
 });
 
 test('handles missing label when showError is true', () => {
-  const { getByTestId } = render(<Textfield showError={true} />);
-  const textfield = getByTestId('texfield');
+  const { container } = render(<Textfield showError={true} />);
+  const textfield = container.querySelector('input');
   expect(textfield).toBeInTheDocument();
 });
 
 test('handles unexpected prop types gracefully', () => {
-  const { getByTestId } = render(<Textfield label={123} defaultLabel={[]}/>);
-  const textfield = getByTestId('texfield');
+  const { container } = render(<Textfield label={123} defaultLabel={[]} />);
+  const textfield = container.querySelector('input');
   expect(textfield).toBeInTheDocument();
 });

--- a/src/components/atoms/User/User.test.js
+++ b/src/components/atoms/User/User.test.js
@@ -5,8 +5,11 @@ import '@testing-library/jest-dom'
 
 
 test('renders user icon', () => {
-  const { getByTestId } = render(<User/>);
-  const userIcon = getByTestId('user-icon');
+  const { container } = render(<User />);
+  
+  const userIcon = container.querySelector('svg');
+  
   expect(userIcon).toBeInTheDocument();
   expect(userIcon).toHaveClass('MuiSvgIcon-root');
+  expect(userIcon).toHaveClass('MuiSvgIcon-fontSizeLarge');
 });


### PR DESCRIPTION
This PR is to modify atoms tests to use queries by roles from react testing library instead of getByTestId